### PR TITLE
feat(#179): Update SlackModule to support user-provided configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 
 @Module({
-  imports: [SlackModule],
+  imports: [SlackModule.forRoot()],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/interfaces/modules/module.options.ts
+++ b/src/interfaces/modules/module.options.ts
@@ -1,0 +1,3 @@
+import { AppOptions } from '@slack/bolt';
+
+export interface SlackModuleOptions extends AppOptions {}

--- a/src/slack.module.ts
+++ b/src/slack.module.ts
@@ -1,39 +1,59 @@
-import { Module, OnApplicationBootstrap } from '@nestjs/common';
+import { DynamicModule, Module, OnApplicationBootstrap } from '@nestjs/common';
 import { ExplorerService } from './services/explorer.service';
 import { SlackService } from './services/slack.service';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { App, AppOptions } from '@slack/bolt';
 import { LoggerProxy } from './loggers/logger.proxy';
+import { SlackModuleOptions } from './interfaces/modules/module.options';
 
 const SLACK = 'Slack';
+const SLACK_MODULE_OPTIONS = 'SLACK_MODULE_OPTIONS';
 
 const slackServiceFactory = {
   provide: 'CONNECTION',
-  useFactory: (configService: ConfigService, loggerProxy: LoggerProxy) => {
+  useFactory: (
+    configService: ConfigService,
+    loggerProxy: LoggerProxy,
+    options: SlackModuleOptions,
+  ) => {
     loggerProxy.setName(SLACK);
-
-    const options: AppOptions = {
+    const opts: AppOptions = {
       logger: loggerProxy,
       token: configService.get('SLACK_BOT_TOKEN'),
       signingSecret: configService.get('SLACK_SIGNING_SECRET'),
       socketMode: !!configService.get<boolean>('SLACK_SOCKET_MODE'),
       appToken: configService.get('SLACK_APP_TOKEN'),
+      ...options,
     };
-    return new App(options);
+    return new App(opts);
   },
-  inject: [ConfigService, LoggerProxy],
+  inject: [ConfigService, LoggerProxy, SLACK_MODULE_OPTIONS],
 };
 
-@Module({
-  imports: [ConfigModule.forRoot()],
-  providers: [ExplorerService, LoggerProxy, SlackService, slackServiceFactory],
-  exports: [SlackService],
-})
+@Module({})
 export class SlackModule implements OnApplicationBootstrap {
   constructor(
     private readonly slackService: SlackService,
     private readonly explorerService: ExplorerService,
-  ) { }
+  ) {}
+
+  static forRoot(options: SlackModuleOptions = {}): DynamicModule {
+    return {
+      module: SlackModule,
+      imports: [ConfigModule.forRoot()],
+      providers: [
+        {
+          provide: SLACK_MODULE_OPTIONS,
+          useValue: options,
+        },
+        ExplorerService,
+        LoggerProxy,
+        SlackService,
+        slackServiceFactory,
+      ],
+      exports: [SlackService],
+    };
+  }
 
   onApplicationBootstrap() {
     const { messages, actions, commands, events, shortcuts } =


### PR DESCRIPTION
BREAKING CHANGE: The SlackModule now requires using the forRoot() method for configuration. Users must update their code to use the forRoot() method when importing the SlackModule.