### PR TITLE
feat: add support for slack module async register

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
-};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestjs-slack-bolt",
-  "version": "1.1.1",
+  "version": "1.2.1",
   "description": "A Nestjs module using Slack Bold SDK",
   "author": "bamada",
   "license": "MIT",

--- a/src/interfaces/events/event-handler.interface.ts
+++ b/src/interfaces/events/event-handler.interface.ts
@@ -1,3 +1,4 @@
 import { IEvent } from './event.interface';
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export interface IEventHandler<T extends IEvent = any> {}

--- a/src/slack.module.ts
+++ b/src/slack.module.ts
@@ -1,13 +1,23 @@
-import { DynamicModule, Module, OnApplicationBootstrap } from '@nestjs/common';
+import {
+  ConfigurableModuleBuilder,
+  Module,
+  OnApplicationBootstrap,
+} from '@nestjs/common';
 import { ExplorerService } from './services/explorer.service';
 import { SlackService } from './services/slack.service';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { App, AppOptions, LogLevel } from '@slack/bolt';
 import { LoggerProxy } from './loggers/logger.proxy';
 import { SlackModuleOptions } from './interfaces/modules/module.options';
+import { SLACK, SLACK_MODULE_OPTIONS } from './tokens';
 
-const SLACK = 'Slack';
-const SLACK_MODULE_OPTIONS = 'SLACK_MODULE_OPTIONS';
+const { ConfigurableModuleClass: SlackModuleConfigurableModuleClass } =
+  new ConfigurableModuleBuilder<SlackModuleOptions>({
+    moduleName: 'SlackModule',
+    optionsInjectionToken: SLACK_MODULE_OPTIONS,
+  })
+    .setClassMethodName('forRoot')
+    .build();
 
 const slackServiceFactory = {
   provide: 'CONNECTION',
@@ -17,43 +27,47 @@ const slackServiceFactory = {
     options: SlackModuleOptions,
   ) => {
     loggerProxy.setName(SLACK);
+    const {
+      token = configService.get<string>('SLACK_BOT_TOKEN'),
+      signingSecret = configService.get<string>('SLACK_SIGNING_SECRET'),
+      socketMode = !!configService.get<boolean>('SLACK_SOCKET_MODE'),
+      appToken = configService.get<string>('SLACK_APP_TOKEN'),
+      logLevel = LogLevel.DEBUG,
+      ...rest
+    } = options ?? {};
+
     const opts: AppOptions = {
       logger: loggerProxy,
-      token: configService.get('SLACK_BOT_TOKEN'),
-      signingSecret: configService.get('SLACK_SIGNING_SECRET'),
-      socketMode: !!configService.get<boolean>('SLACK_SOCKET_MODE'),
-      appToken: configService.get('SLACK_APP_TOKEN'),
-      logLevel: options.logLevel ?? LogLevel.DEBUG,
-      ...options,
+      token,
+      signingSecret,
+      socketMode,
+      appToken,
+      logLevel,
+      ...rest,
     };
     return new App(opts);
   },
   inject: [ConfigService, LoggerProxy, SLACK_MODULE_OPTIONS],
 };
 
-@Module({})
-export class SlackModule implements OnApplicationBootstrap {
+@Module({
+  imports: [ConfigModule.forRoot()],
+  providers: [ExplorerService, LoggerProxy, SlackService, slackServiceFactory],
+  exports: [SlackService],
+})
+export class SlackModule
+  extends SlackModuleConfigurableModuleClass
+  implements OnApplicationBootstrap
+{
   constructor(
     private readonly slackService: SlackService,
     private readonly explorerService: ExplorerService,
-  ) {}
+  ) {
+    super();
+  }
 
-  static forRoot(options: SlackModuleOptions = {}): DynamicModule {
-    return {
-      module: SlackModule,
-      imports: [ConfigModule.forRoot()],
-      providers: [
-        {
-          provide: SLACK_MODULE_OPTIONS,
-          useValue: options,
-        },
-        ExplorerService,
-        LoggerProxy,
-        SlackService,
-        slackServiceFactory,
-      ],
-      exports: [SlackService],
-    };
+  static forRoot(options?: SlackModuleOptions) {
+    return super.forRoot(options ?? {});
   }
 
   onApplicationBootstrap() {

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -1,0 +1,2 @@
+export const SLACK = 'Slack';
+export const SLACK_MODULE_OPTIONS = 'SLACK_MODULE_OPTIONS';


### PR DESCRIPTION
use nestjs ConfigurableModuleClassBuilder to enable `forRootAsync` method of registering the module